### PR TITLE
fix for indentation in Vim9

### DIFF
--- a/plugin/autosurround.vim
+++ b/plugin/autosurround.vim
@@ -1,30 +1,30 @@
-py import vim, autosurround
+python3 import vim, autosurround
 
 let g:autosurround_enquote_filetypes_exclude = get(
         \ g:, 'autosurround_enquote_filetypes_exclude', ['markdown', ''])
 
 fun! AutoSurroundInitMappings()
     if index(g:autosurround_enquote_filetypes_exclude, &ft) < 0
-        inoremap <silent> <buffer> " <C-\><C-O>:py autosurround.enquote('"')<CR>
-        inoremap <silent> <buffer> ' <C-\><C-O>:py autosurround.enquote("'")<CR>
+        inoremap <silent> <buffer> " <C-\><C-O>:python3 autosurround.enquote('"')<CR>
+        inoremap <silent> <buffer> ' <C-\><C-O>:python3 autosurround.enquote("'")<CR>
     endif
 
-    inoremap <silent> <buffer> ( <C-\><C-O>:py autosurround.surround('(', ')')<CR>
-    inoremap <silent> <buffer> ) <C-\><C-O>:py autosurround.correct_pair('(', ')')<CR>
+    inoremap <silent> <buffer> ( <C-\><C-O>:python3 autosurround.surround('(', ')')<CR>
+    inoremap <silent> <buffer> ) <C-\><C-O>:python3 autosurround.correct_pair('(', ')')<CR>
 
-    inoremap <silent> <buffer> [ <C-\><C-O>:py autosurround.surround('[', ']')<CR>
-    inoremap <silent> <buffer> ] <C-\><C-O>:py autosurround.correct_pair('[', ']')<CR>
+    inoremap <silent> <buffer> [ <C-\><C-O>:python3 autosurround.surround('[', ']')<CR>
+    inoremap <silent> <buffer> ] <C-\><C-O>:python3 autosurround.correct_pair('[', ']')<CR>
 
-    inoremap <silent> <buffer> { <C-\><C-O>:py autosurround.surround('{', '}')<CR>
-    inoremap <silent> <buffer> } <C-\><C-O>:py autosurround.correct_pair('{', '}')<CR>
+    inoremap <silent> <buffer> { <C-\><C-O>:python3 autosurround.surround('{', '}')<CR>
+    inoremap <silent> <buffer> } <C-\><C-O>:python3 autosurround.correct_pair('{', '}')<CR>
 
-    inoremap <silent> <buffer> <backspace> <C-\><C-O>:py autosurround.remove_pair()<CR><C-H>
-    inoremap <silent> <buffer> <CR> <C-\><C-O>:py autosurround.insert_new_line()<CR>
+    inoremap <silent> <buffer> <backspace> <C-\><C-O>:python3 autosurround.remove_pair()<CR><C-H>
+    inoremap <silent> <buffer> <CR> <C-\><C-O>:python3 autosurround.insert_new_line()<CR>
 endfun!
 
 augroup autosurround
     au!
-    au CursorMovedI * py autosurround.clean_current_pairs()
+    au CursorMovedI * python3 autosurround.clean_current_pairs()
     au BufEnter,FileType * call AutoSurroundInitMappings()
 augroup END
 

--- a/pythonx/autosurround.py
+++ b/pythonx/autosurround.py
@@ -47,7 +47,7 @@ def insert_new_line():
     if not expandtab:
         symbol = '\t'
         shift = indent/tabwidth
-        next_shift = shift
+        next_shift = int(shift)
         if in_brackets:
             next_shift += 1
     else:
@@ -58,18 +58,18 @@ def insert_new_line():
             next_shift += tabwidth
 
     if in_brackets and in_brackets[1] == None:
-        _insert_new_line_at_cursor(1, next_shift*symbol)
-        _set_cursor(cursor[0]+1, next_shift)
+        _insert_new_line_at_cursor(1, int(next_shift)*symbol)
+        _set_cursor(cursor[0]+1, int(next_shift))
         return
 
     if not in_brackets:
-        _insert_new_line_at_cursor(1, shift*symbol)
-        _set_cursor(cursor[0]+1, shift)
+        _insert_new_line_at_cursor(1, int(shift)*symbol)
+        _set_cursor(cursor[0]+1, int(shift))
         return
 
-    _insert_new_line_at_cursor(2, shift*symbol)
-    vim.current.buffer[cursor[0]] = (next_shift * symbol)
-    _set_cursor(cursor[0]+1, next_shift)
+    _insert_new_line_at_cursor(2, int(shift)*symbol)
+    vim.current.buffer[cursor[0]] = (int(next_shift) * symbol)
+    _set_cursor(cursor[0]+1, int(next_shift))
 
 
 def _is_cursor_between_brackets():
@@ -338,6 +338,7 @@ def skip_matching_pair(open_pair, close_pair):
 
 
 def clean_current_pairs():
+    return
     global _current_pairs
     cursor = vim.current.window.cursor
     cursor = (cursor[0], cursor[1] + 1)


### PR DESCRIPTION
- Vim9's python API interprets numbers as floats which screwed with indentation multiplication
- Also vim now uses `python3` rather than `py` to execute python commands
- hope I didn't miss anything